### PR TITLE
fix(release): remove registry-url to stop pnpm auth override

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,19 +57,20 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
-          # Configures the npm registry and writes NODE_AUTH_TOKEN into .npmrc.
-          registry-url: 'https://registry.npmjs.org'
+          # No registry-url here — setup-node would set NPM_CONFIG_USERCONFIG to
+          # a temp file containing the literal string "${NODE_AUTH_TOKEN}" which
+          # pnpm does not expand, causing 401/404. We write the token ourselves.
           cache: 'pnpm'
 
-      - run: pnpm install --frozen-lockfile
-
-      # Write auth token directly into .npmrc so both npm and pnpm pick it up.
-      # actions/setup-node writes to a temp .npmrc via NPM_CONFIG_USERCONFIG but
-      # pnpm publish doesn't always honour that env var.
+      # Write the real token value (not a variable reference) directly to
+      # ~/.npmrc. Because NPM_CONFIG_USERCONFIG is not set, pnpm finds this file
+      # via the standard npm config resolution order.
       - name: Configure npm auth
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - run: pnpm install --frozen-lockfile
 
       # Build in dependency order: core must be built before cli, because cli
       # imports from dc2mermaid-core at its workspace path.


### PR DESCRIPTION
## Problem

`actions/setup-node` with `registry-url` sets `NPM_CONFIG_USERCONFIG` to a temp `.npmrc` that contains the **literal string** `${NODE_AUTH_TOKEN}` — not the expanded value. pnpm does not perform shell-style `${VAR}` expansion when reading `.npmrc`, so every publish step was authenticating with the placeholder string, causing a 404.

Evidence from the last failed run: the log showed `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX` (unmasked placeholder) rather than `***` (a real secret), confirming the token was never injected.

## Fix

- Remove `registry-url` from `actions/setup-node` — prevents the temp `.npmrc` from being created and `NPM_CONFIG_USERCONFIG` from being set.
- The existing "Configure npm auth" step already writes the real token value (bash expands `$NPM_TOKEN` in the `run:` shell before writing) to `~/.npmrc`, which pnpm reads normally.
- Move `pnpm install` after the auth step for a cleaner ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)